### PR TITLE
Track properties dont disappear

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/runpharaa/MapsActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/MapsActivity.java
@@ -19,6 +19,7 @@ import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import ch.epfl.sweng.runpharaa.tracks.Track;
@@ -29,16 +30,19 @@ public final class MapsActivity extends LocationUpdateReceiverActivity implement
 
     private GoogleMap mMap;
     private TextView testText;
+    private List<Marker> markers; // used to check if a windowInfo is opened
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_maps);
         testText = findViewById(R.id.maps_test_text);
+
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        markers = new ArrayList<>();
     }
 
     /**
@@ -54,27 +58,32 @@ public final class MapsActivity extends LocationUpdateReceiverActivity implement
         InfoWindowGoogleMap customInfoWindow = new InfoWindowGoogleMap(this);
         mMap.setInfoWindowAdapter(customInfoWindow);
         testText.setText("ready");
-
         handleNewLocation();
     }
 
     @Override
     protected void handleNewLocation() {
+
+        // If an infoWindow is opened, the map is not updated to prevent the window to be closed
+        if (infoWindowOpen())
+            return;
+
         mMap.clear();
+        markers.clear();
 
         int transparentBlue = 0x2f0000ff;
         int transBlueBorder = 0x000000ff;
 
-        //add a circle around the current location
+        // Add a circle around the current location
         mMap.addCircle(new CircleOptions()
                 .center(User.instance.getLocation())
                 .radius(User.instance.getPreferredRadius())
                 .fillColor(transparentBlue)
                 .strokeColor(transBlueBorder));
-        //follow the user
+        // Follow the user
         mMap.moveCamera(CameraUpdateFactory.newLatLng(User.instance.getLocation()));
 
-        //add a marker for each starting point inside the preferred radius
+        // Add a marker for each starting point inside the preferred radius
         DatabaseManagement.mReadDataOnce(DatabaseManagement.TRACKS_PATH, new DatabaseManagement.OnGetDataListener() {
             @Override
             public void onSuccess(DataSnapshot data) {
@@ -84,6 +93,8 @@ public final class MapsActivity extends LocationUpdateReceiverActivity implement
                             .position(t.getStartingPoint().ToLatLng())
                             .title(t.getName()));
                     m.setTag(t.getTrackUid());
+
+                    markers.add(m);
                 }
             }
 
@@ -99,6 +110,21 @@ public final class MapsActivity extends LocationUpdateReceiverActivity implement
         Intent i = new Intent(this, TrackPropertiesActivity.class);
         i.putExtra("TrackID", (String) marker.getTag());
         startActivity(i);
+    }
+
+    /**
+     * Check if any present marker on the google map has its infoWindow opened
+     * As only one infoWindow can be open, return true as soon as a marker has its infoWindow opened
+     *
+     * @return true if an infoWindow is open
+     */
+    private boolean infoWindowOpen() {
+        for (Marker m : markers) {
+            if (m.isInfoWindowShown()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Bugfix: 

The info window that appear when we click on a marker on the Google Map no longuer disappear when the phone location is updated.

As the map has to be entirely cleared to refresh the markers and blue circle, the info window will blink off and on everytime the location is updated though.