### PR TITLE
Now only redownload data on when user refresh

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/runpharaa/SettingsActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/runpharaa/SettingsActivityTest.java
@@ -81,23 +81,23 @@ public class SettingsActivityTest {
 
     @Test
     public void correctlyUpdatesPrefRadius() {
-        writeTextToPreference("100", 1);
-        assertTrue(User.instance.getPreferredRadius() == 100);
+        writeTextToPreference("1.5", 1);
+        assertTrue(User.instance.getPreferredRadius() == 1500);
     }
 
     @Test
     public void correctlyUpdatesMinTimeInterval() {
-        writeTextToPreference("2000", 4);
+        writeTextToPreference("2", 4);
     }
 
     @Test
     public void correctlyUpdatesTimeInterval() {
-        writeTextToPreference("6000", 3);
+        writeTextToPreference("6", 3);
     }
 
     @Test
     public void correctlyUpdatesDistanceInterval() {
-        writeTextToPreference("10", 5);
+        writeTextToPreference("1", 5);
     }
 
     @Test

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentFavourites.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentFavourites.java
@@ -91,7 +91,8 @@ public class FragmentFavourites extends Fragment implements SwipeRefreshLayout.O
     SwipeRefreshLayout swipeLayout;
     TextView emptyMessage;
 
-    public FragmentFavourites() { }
+    public FragmentFavourites() {
+    }
 
     public interface OnItemClickListener {
         void onItemClick(CardItem item);
@@ -107,6 +108,8 @@ public class FragmentFavourites extends Fragment implements SwipeRefreshLayout.O
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         v = inflater.inflate(R.layout.updatable_fragment, container, false);
 
+        Log.i("FragmentNearMeLife", "F: on create view");
+
         emptyMessage = v.findViewById(R.id.emptyMessage);
         emptyMessage.setVisibility(View.GONE);
 
@@ -115,22 +118,10 @@ public class FragmentFavourites extends Fragment implements SwipeRefreshLayout.O
         swipeLayout.setOnRefreshListener(this);
         swipeLayout.setColorSchemeResources(R.color.refresh_orange, R.color.refresh_red, R.color.refresh_blue, R.color.refresh_green);
 
-        // Load if the fragment is visible
-        if (getUserVisibleHint()) {
-            loadData();
-        }
+        // Load data initially
+        loadData();
 
         return v;
-    }
-
-    @Override
-    public void setUserVisibleHint(boolean isVisibleToUser) {
-        super.setUserVisibleHint(isVisibleToUser);
-
-        // If the fragment is visible, reload the data
-        if (isVisibleToUser && isResumed()) {
-            onResume();
-        }
     }
 
     @Override
@@ -143,12 +134,6 @@ public class FragmentFavourites extends Fragment implements SwipeRefreshLayout.O
     @Override
     public void onResume() {
         super.onResume();
-        // Do nothing if the fragment is not visible
-        if (!getUserVisibleHint()) {
-            return;
-        }
-        // Else load the data
-        loadData();
     }
 
     /**
@@ -181,7 +166,7 @@ public class FragmentFavourites extends Fragment implements SwipeRefreshLayout.O
                 recyclerView.setAdapter(adapter);
                 recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
-                if(listCardItem.isEmpty())
+                if (listCardItem.isEmpty())
                     setEmptyMessage();
             }
 

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentFollowing.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentFollowing.java
@@ -57,15 +57,13 @@ public class FragmentFollowing extends Fragment implements SwipeRefreshLayout.On
         swipeLayout.setOnRefreshListener(this);
         swipeLayout.setColorSchemeResources(R.color.refresh_orange, R.color.refresh_red, R.color.refresh_blue, R.color.refresh_green);
 
-        // Load if the fragment is visible
-        if (getUserVisibleHint()) {
-            loadData();
-        }
+        // Load data the first time
+        loadData();
 
         return v;
     }
 
-    @Override
+    /*@Override
     public void setUserVisibleHint(boolean isVisibleToUser) {
         super.setUserVisibleHint(isVisibleToUser);
 
@@ -73,7 +71,7 @@ public class FragmentFollowing extends Fragment implements SwipeRefreshLayout.On
         if (isVisibleToUser && isResumed()) {
             onResume();
         }
-    }
+    }*/
 
     @Override
     public void onRefresh() {
@@ -86,11 +84,11 @@ public class FragmentFollowing extends Fragment implements SwipeRefreshLayout.On
     public void onResume() {
         super.onResume();
         // Do nothing if the fragment is not visible
-        if (!getUserVisibleHint()) {
-            return;
-        }
+        //if (!getUserVisibleHint()) {
+        //    return;
+        //}
         // Else load the data
-        loadData();
+        //loadData();
     }
 
     public void loadData() {

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentNearMe.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/FragmentNearMe.java
@@ -52,6 +52,8 @@ public class FragmentNearMe extends Fragment implements SwipeRefreshLayout.OnRef
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         v = inflater.inflate(R.layout.updatable_fragment, container, false);
 
+        Log.i("FragmentNearMeLife", "on create view");
+
         emptyMessage = v.findViewById(R.id.emptyMessage);
         emptyMessage.setVisibility(View.GONE);
 
@@ -61,39 +63,43 @@ public class FragmentNearMe extends Fragment implements SwipeRefreshLayout.OnRef
         swipeLayout.setColorSchemeResources(R.color.refresh_orange, R.color.refresh_red, R.color.refresh_blue, R.color.refresh_green);
 
         // Load if the fragment is visible
-        if (getUserVisibleHint()) {
+        //if (getUserVisibleHint()) {
             loadData();
-        }
+        //}
 
         return v;
     }
 
-    @Override
+    /*@Override
     public void setUserVisibleHint(boolean isVisibleToUser) {
         super.setUserVisibleHint(isVisibleToUser);
 
+        Log.i("FragmentNearMeLife", "set user visible hint");
+
         // If the fragment is visible, reload the data
-        if (isVisibleToUser && isResumed()) {
-            onResume();
-        }
-    }
+        //if (isVisibleToUser && isResumed()) {
+        //    onResume();
+        //}
+    }*/
 
     @Override
     public void onRefresh() {
+        Log.i("FragmentNearMeLife", "on refresh");
         loadData();
         // Stop refreshing once it is done
-        swipeLayout.setRefreshing(false);
+        //swipeLayout.setRefreshing(false);
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        Log.i("FragmentNearMeLife", "on resume");
         // Do nothing if the fragment is not visible
-        if (!getUserVisibleHint()) {
-            return;
-        }
+        //if (!getUserVisibleHint()) {
+        //    return;
+        //}
         // Else load the data
-        loadData();
+        //loadData();
     }
 
     /**
@@ -104,6 +110,8 @@ public class FragmentNearMe extends Fragment implements SwipeRefreshLayout.OnRef
         emptyMessage.setVisibility(View.GONE);
         // Create a fresh recyclerView and listCardItem
         String s = DatabaseManagement.TRACKS_PATH;
+
+        Log.i("FragmentNearMeLife", "load data");
 
         DatabaseManagement.OnGetDataListener d = new DatabaseManagement.OnGetDataListener() {
             @Override
@@ -127,12 +135,15 @@ public class FragmentNearMe extends Fragment implements SwipeRefreshLayout.OnRef
 
                 if(listCardItem.isEmpty())
                     setEmptyMessage();
+
+                swipeLayout.setRefreshing(false);
             }
 
             @Override
             public void onFailed(DatabaseError databaseError) {
                 Log.d("DB Read: ", "Failed to read data from DB in FragmentNearMe.");
                 setEmptyMessage();
+                swipeLayout.setRefreshing(false);
             }
         };
 

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/GpsService.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/GpsService.java
@@ -123,14 +123,13 @@ public class GpsService extends Service implements GoogleApiClient.ConnectionCal
         locationRequest = LocationRequest.create().setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
         // Get pref values or default ones
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-        int timeInterval = getInt(sp, SettingsActivity.PREF_KEY_TIME_INTERVAL, 5000);
-        int minTimeInterval = getInt(sp, SettingsActivity.PREF_KEY_MIN_TIME_INTERVAL, 1000);
+        int timeInterval = getInt(sp, SettingsActivity.PREF_KEY_TIME_INTERVAL, 5);
+        int minTimeInterval = getInt(sp, SettingsActivity.PREF_KEY_MIN_TIME_INTERVAL, 1);
         int minDistance = getInt(sp, SettingsActivity.PREF_KEY_MIN_DISTANCE, 5);
         // Set the values
-        locationRequest
-                .setInterval(timeInterval)
-                .setFastestInterval(minTimeInterval)
-                .setSmallestDisplacement(minDistance);
+        setTimeInterval(timeInterval);
+        setMinTimeInterval(minTimeInterval);
+        setMinDistanceInterval(minDistance);
     }
 
     private void initLocationCallBack() {
@@ -151,7 +150,7 @@ public class GpsService extends Service implements GoogleApiClient.ConnectionCal
      */
     public static void setTimeInterval(int newTimeInterval) {
         if(locationRequest != null) {
-            locationRequest.setInterval(newTimeInterval);
+            locationRequest.setInterval(newTimeInterval * 1000);
         }
     }
 

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/MainActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/MainActivity.java
@@ -83,6 +83,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Link all
         viewPager.setAdapter(adapter);
+        viewPager.setOffscreenPageLimit(3);
         tabLayout.setupWithViewPager(viewPager);
 
         // Set icons

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/database/UserDatabaseManagement.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/database/UserDatabaseManagement.java
@@ -1,6 +1,7 @@
 package ch.epfl.sweng.runpharaa.database;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -25,8 +26,7 @@ public class UserDatabaseManagement extends DatabaseManagement {
             @Override
             public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 if(dataSnapshot.child(user.getID()).exists()){
-                    downloadUser(user.getID());
-                    callback.onSuccess(User.instance);
+                    downloadUser(user.getID(), callback);
                 }else{
                     DatabaseReference userRef = mDataBaseRef.child(USERS).child(user.getID());
                     userRef.setValue(user.getFirebaseAdapter()).addOnSuccessListener(aVoid -> callback.onSuccess(user)).addOnFailureListener(callback::onError);
@@ -72,7 +72,7 @@ public class UserDatabaseManagement extends DatabaseManagement {
         createRef.setValue(trackID).addOnFailureListener(Throwable::printStackTrace);
     }
 
-    public static void downloadUser(final String UID){
+    public static void downloadUser(final String UID, final Callback<User> whenFinishedCallback){
         downloadUserTracks(UID, CREATE, new Callback<Set<String>>() {
             @Override
             public void onSuccess(Set<String> createdTracks) {
@@ -85,6 +85,7 @@ public class UserDatabaseManagement extends DatabaseManagement {
                                 User.instance.setCreatedTracks(createdTracks);
                                 User.instance.setFavoriteTracks(favoriteTracks);
                                 User.instance.setLikedTracks(likedTracks);
+                                whenFinishedCallback.onSuccess(User.instance);
                             }
                         });
                     }
@@ -103,6 +104,7 @@ public class UserDatabaseManagement extends DatabaseManagement {
             public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 Set<String> createdTracks = new HashSet<>();
                 for(DataSnapshot createdSnapshot: dataSnapshot.getChildren()){
+                    Log.i("AfricaToto", type+" adding "+ createdSnapshot.getKey());
                     createdTracks.add(createdSnapshot.getKey());
                 }
 

--- a/app/src/main/java/ch/epfl/sweng/runpharaa/user/User.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/user/User.java
@@ -55,7 +55,7 @@ public final class User {
     }
 
     public static void set(String name, float preferredRadius, Uri picture, LatLng location, String uId) {
-        instance = new User(name, (int)(preferredRadius*100), picture, location, uId);
+        instance = new User(name, (int)(preferredRadius*1000), picture, location, uId);
     }
 
     public FirebaseUserAdapter getFirebaseAdapter() {


### PR DESCRIPTION
All data loads initially when the app is first launched, then the user must pull down to refresh to avoid useless downloads and slow loading times.