### PR TITLE
Start the new thread in updateUI

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/runpharaa/login/LoginActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/runpharaa/login/LoginActivity.java
@@ -135,7 +135,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                         Toast.makeText(getBaseContext(), "Authentication Failed.", Toast.LENGTH_SHORT).show();
                     }
                 });
-            });
+            }).start();
         } else {
             setContentView(R.layout.activity_login);
             TextView tv = findViewById(R.id.textViewLogin);


### PR DESCRIPTION
Quick fix to avoid infinite loop while loading user's data.

- The new thread was not started in the updateUI() method in LoginActivity.java